### PR TITLE
Modern builds and print update

### DIFF
--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -1,0 +1,164 @@
+@media print {
+
+  /* always hide sidebar in printing mode */
+  .sidenav {
+    display: none;
+  }
+
+  * {
+    overflow: visible !important;
+  }
+
+  body, html {
+    background-color: white !important;
+  }
+
+  .header {
+    position: static !important;
+  }
+
+  .planYear {
+    position: absolute !important;
+    font-family: Inter, sans-serif;
+    font-weight: 300;
+    font-size: 16px !important;
+    letter-spacing: 0px;
+    padding: 0px !important;
+    width: auto !important;
+    background: white !important;
+    right: 20px !important;
+    border: none;
+  }
+
+  .plotsSidebar {
+    display: none;
+  }
+
+  .cropsSidebar {
+    display: none;
+  }
+
+  .cropsTable {
+    width: 100% !important;
+  }
+
+  .cropsTable .table {
+    margin-top: 10px !important;
+  }
+
+  .timeseries-wrapper {
+    height: 50vw !important;
+    width: 100% !important;
+  }
+
+  .cropLabour-wrapper {
+    height: 50vw !important;
+    width: 100% !important;
+  }
+
+  .printFixOverflow {
+    overflow: hidden !important;
+  }
+
+  .dropdown-header {
+    display: none;
+  }
+  .printCropName {
+    display: block !important;
+    text-align: center;
+    font-size: 12px;
+    margin-top: 20px;
+  }
+
+  .button {
+    display: none;
+  }
+
+  .navIcon {
+    display: none;
+  }
+
+  .logo {
+    padding-left: 20px !important;
+  }
+
+  .logo:after {
+    content: "Planungsjahr";
+    font-family: Inter, sans-serif;
+    font-weight: 300;
+    font-size: 16px;
+    letter-spacing: 0em;
+    position: absolute;
+    top: 0px;
+    right: 125px;
+  }
+  .printPageName {
+    display: block !important;
+    position: absolute;
+    top: 0px;
+    text-align: center;
+    width: 100%;
+  }
+  .nuxt {
+    width: 100%;
+    position: static;
+    top: 0px;
+    margin: 0;
+    padding: 0;
+    margin-left: 0px !important;
+    background: none;
+  }
+
+  .table {
+    width: 100%;
+    table-layout: auto;
+    font-family: Georgia, serif;
+  }
+
+  .table tr:nth-child(odd) {
+    background-color: #f5f5f5;
+  }
+
+  .sidenav-links.active {
+    content: attr(title);
+    position: absolute;
+    top: 0px;
+    display: inline !important;
+  }
+
+  th {
+    color: black !important;
+    background-color: white !important;
+    border-bottom: 1px solid #ececec;
+  }
+
+  .selection {
+    font-size: 12px;
+    font-family: Georgia, serif !important;
+    -moz-text-align-last: left;
+    text-align-last: left;
+    width: 100%;
+    font-family: Inter;
+    font-weight: 300;
+    letter-spacing: normal;
+    border-width: 0px;
+    padding: 0px;
+    background: none !important;
+    background-color: inherit !important;
+  }
+
+  input[type="checkbox"] {
+    display: none;
+  }
+
+  input[type="checkbox"][checked="checked"] {
+    display: inline-block;
+  }
+  .VueCarousel {
+    overflow: hidden !important;
+  }
+  .result-table {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+}

--- a/components/add_plot.vue
+++ b/components/add_plot.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script>
-import { area } from '@turf/turf'
+import area from '@turf/area'
 import cultures from '~/assets/js/cultures.js'
 import notifications from '~/components/notifications'
 

--- a/components/crop_table.vue
+++ b/components/crop_table.vue
@@ -1,5 +1,8 @@
 <template lang="html">
   <div class="cropsTable">
+    <div style="display: none;" class="printCropName">
+      {{ crop.name }}
+    </div>
     <table class="table">
       <thead>
         <tr>

--- a/components/download.vue
+++ b/components/download.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-import XLSX from 'xlsx'
+import { utils, writeFile } from 'xlsx'
 
 export default {
   props: {
@@ -145,10 +145,10 @@ export default {
           Nummer: crop.data
         })
       })
-      const exportWS = XLSX.utils.json_to_sheet(exportData, { header: order })
-      const wb = XLSX.utils.book_new() // make Workbook of Excel
+      const exportWS = utils.json_to_sheet(exportData, { header: order })
+      const wb = utils.book_new() // make Workbook of Excel
       // add Worksheet to Workbook
-      XLSX.utils.book_append_sheet(wb, exportWS, 'Fruchtfolge')
+      utils.book_append_sheet(wb, exportWS, 'Fruchtfolge')
       // export Excel file
       // count plots in red area
       const red = this.data.reduce((acc, cur) => {
@@ -160,8 +160,8 @@ export default {
       let opt = 'Opt'
       if (this.data[0].allowedCrops && this.data[0].allowedCrops.length)
         opt = 'NoOpt'
-      // XLSX.writeFile(wb, `Fruchtfolge - Planung ${this.year}.xlsx`)
-      XLSX.writeFile(wb, `Fruchtfolge - ${red} red area - ${opt}.xlsx`)
+      // writeFile(wb, `Fruchtfolge - Planung ${this.year}.xlsx`)
+      writeFile(wb, `Fruchtfolge - ${red} red area - ${opt}.xlsx`)
     }
   }
 }

--- a/components/maps.vue
+++ b/components/maps.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script>
-import { area } from '@turf/turf'
+import area from '@turf/area'
 import mapboxgl from 'mapbox-gl'
 import MapboxDraw from '@mapbox/mapbox-gl-draw'
 import drawConfig from '../assets/js/draw.config.js'

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,6 +5,10 @@
       <div class="logo">
         FRUCHTFOLGE
       </div>
+      <!-- show currently active page at the top when in print mode -->
+      <div style="display: none;" class="printPageName">
+        {{ curPageName }}
+      </div>
       <!-- Planning year selector -->
       <select
         v-model="settings.curYear"
@@ -29,6 +33,7 @@
           v-for="(route, index) in routes"
           :key="index"
           class="sidenav-links"
+          :title="route.name"
           :class="{ active: isClicked(route), subPage: route.subPage }"
           @click="follow(route)"
         >
@@ -90,6 +95,13 @@ export default {
         backgroundColor: 'rgba(0, 0, 0, .05)'
       },
       routes
+    }
+  },
+  computed: {
+    curPageName() {
+      const clicked = this.routes.find(route => route.path === this.curPage)
+      if (clicked) return _.capitalize(clicked.name)
+      return ''
     }
   },
   async created() {

--- a/layouts/home.vue
+++ b/layouts/home.vue
@@ -14,7 +14,7 @@
     <nuxt class="nuxt" />
     <!-- Footer for legal texts-->
     <footer class="footer">
-      <p>Fruchtfolge Version {{ version }} - Economic Modeling of Agricultural Systems Group - ILR - Universität Bonn</p>
+      <p>Fruchtfolge Version {{ version }} - <a href="https://www.ilr.uni-bonn.de/em/em_e.htm" target="_blank" style="text-decoration: none; color: inherit;">Economic Modeling of Agricultural Systems Group - ILR - Universität Bonn</a></p>
       <nuxt-link class="link" to="/kontakt">
         Kontakt
       </nuxt-link>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -79,6 +79,7 @@ module.exports = {
   css: [
     '@/assets/css/global.css',
     '@/assets/css/grid.css',
+    '@/assets/css/print.css',
     '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css',
     'mapbox-gl/dist/mapbox-gl.css'
   ],

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -17,6 +17,7 @@ module.exports = {
   server: {
     port: 3002
   },
+  modern: true,
   /*
   ** Headers of the page
   */
@@ -28,7 +29,12 @@ module.exports = {
         name: 'viewport',
         content: 'width=device-width, user-scalable=no, initial-scale=1'
       },
-      { hid: 'description', name: 'description', content: pkg.description }
+      {
+        hid: 'description',
+        name: 'description',
+        content:
+          'Mit wenigen Klicks die Anbauplanung optimieren. Düngeverordnung 2020 mit inbegriffen!'
+      }
     ],
     script: [
       {
@@ -139,6 +145,8 @@ module.exports = {
         __dirname,
         'node_modules/@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.js'
       )
+
+      alias.xlsx = path.resolve(__dirname, 'node_modules/xlsx/xlsx.mini.js')
 
       const vueLoader = config.module.rules.find(r => r.loader === 'vue-loader')
       vueLoader.options.transformToRequire = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fruchtfolge",
-  "version": "2.0.0",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -967,20 +967,34 @@
       "integrity": "sha1-HaHms6et060pkJsw9Dj2BYG3zYA="
     },
     "@mapbox/geojson-rewind": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.4.1.tgz",
-      "integrity": "sha512-mxo2MEr7izA1uOXcDsw99Kgg6xW3P4H2j4n1lmldsgviIelpssvP+jQDivFKOHrOVJDpTTi5oZJvRcHtU9Uufw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.0.tgz",
+      "integrity": "sha512-73l/qJQgj/T/zO1JXVfuVvvKDgikD/7D/rHAD28S9BG1OTstgmftrmqfCx4U+zQAmtsB6HcDA3a7ymdnJZAQgg==",
       "requires": {
-        "@mapbox/geojson-area": "0.2.2",
-        "concat-stream": "~1.6.0",
-        "minimist": "^1.2.5",
-        "sharkdown": "^0.1.0"
+        "concat-stream": "~2.0.0",
+        "minimist": "^1.2.5"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        "concat-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
         }
       }
     },
@@ -999,6 +1013,13 @@
         "minimist": "1.2.0",
         "vfile": "^4.0.0",
         "vfile-reporter": "^5.1.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
       }
     },
     "@mapbox/jsonlint-lines-primitives": {
@@ -1673,1336 +1694,58 @@
         }
       }
     },
-    "@turf/along": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
-      "integrity": "sha1-YdbmplhKzdq1asVYTge/jL5fi+s=",
-      "requires": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
     "@turf/area": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
-      "integrity": "sha1-79iZv9Jgzb0VQbKjwVX4pdLu+h0=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.0.1.tgz",
+      "integrity": "sha512-Zv+3N1ep9P5JvR0YOYagLANyapGWQBh8atdeR3bKpWcigVXFsEKNUw03U/5xnh+cKzm7yozHD6MFJkqQv55y0g==",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
+          "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
+        },
+        "@turf/meta": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
+          "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+          "requires": {
+            "@turf/helpers": "6.x"
+          }
+        }
       }
     },
     "@turf/bbox": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
-      "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.0.1.tgz",
+      "integrity": "sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/bbox-clip": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
-      "integrity": "sha1-M2S1Mo3/nzz0HZ4C7a/zdNFQzIQ=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "lineclip": "^1.1.5"
-      }
-    },
-    "@turf/bbox-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
-      "integrity": "sha1-auuk7VHYXSluD3w4uIwznwHu4CQ=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/bearing": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
-      "integrity": "sha1-egt5ATbE70eX8CRjBdRcvi0ns/c=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/bezier-spline": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
-      "integrity": "sha1-WaJ7ul17l+8Vqz/VpA+9I4cEm8o=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/boolean-clockwise": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
-      "integrity": "sha1-MwK32sYsXikaB4nimvcoM4f6nes=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/boolean-contains": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
-      "integrity": "sha1-WW1jruY2961T7pn5/yTJaZSg7xQ=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/boolean-point-on-line": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/boolean-crosses": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
-      "integrity": "sha1-Ab+uollvFk3kpNMlCU3HwlXHFdY=",
-      "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/polygon-to-line": "^5.1.5"
-      }
-    },
-    "@turf/boolean-disjoint": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
-      "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
-      "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/polygon-to-line": "^5.1.5"
-      }
-    },
-    "@turf/boolean-equal": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
-      "integrity": "sha1-Kfj21gu4RQff12WzIlTbjnLJOKQ=",
-      "requires": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "geojson-equality": "0.1.6"
-      }
-    },
-    "@turf/boolean-overlap": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
-      "integrity": "sha1-DU5kxSx3CijpPZ7834qLg3OsznU=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/line-overlap": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "geojson-equality": "0.1.6"
-      }
-    },
-    "@turf/boolean-parallel": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
-      "integrity": "sha1-c5NYR16ltlx+GCejw+DopofTqF0=",
-      "requires": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5"
-      }
-    },
-    "@turf/boolean-point-in-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
-      "integrity": "sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/boolean-point-on-line": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
-      "integrity": "sha1-9jPF/4Aq0ku48Vja269v9KAj3Xs=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/boolean-within": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
-      "integrity": "sha1-RxBdVtB1Kp0Pv81Dw2pfkUnchpc=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/boolean-point-on-line": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/buffer": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
-      "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/projection": "^5.1.5",
-        "d3-geo": "1.7.1",
-        "turf-jsts": "*"
-      }
-    },
-    "@turf/center": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
-      "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/center-mean": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
-      "integrity": "sha1-jI6YdTkeXwnw5uePXWYbiLIQigo=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/center-median": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
-      "integrity": "sha1-u0Yb/noqSGAdikcnaFcYcjoUqHI=",
-      "requires": {
-        "@turf/center-mean": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/center-of-mass": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
-      "integrity": "sha1-TTvXnYhJjbq4Mk1PafAyL2Uguco=",
-      "requires": {
-        "@turf/centroid": "^5.1.5",
-        "@turf/convex": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/centroid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
-      "integrity": "sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/circle": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
-      "integrity": "sha1-mxV3g1UIq1L7HBCypQZcuiuHtqU=",
-      "requires": {
-        "@turf/destination": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/clean-coords": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
-      "integrity": "sha1-EoAKmKeMmkUqcuxChJPEOs8q2h8=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/clone": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
-      "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/clusters": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
-      "integrity": "sha1-ZzpeXxsZycq6vFfJCO6t1oIiTdQ=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/clusters-dbscan": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
-      "integrity": "sha1-V4H7TmVsdHoLjpk333MYHAMJ4m8=",
-      "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "density-clustering": "1.3.0"
-      }
-    },
-    "@turf/clusters-kmeans": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
-      "integrity": "sha1-/W3+qLEzuovcI3CsPKzuFYejAvE=",
-      "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "skmeans": "0.9.7"
-      }
-    },
-    "@turf/collect": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
-      "integrity": "sha1-/pjJqMIY7PJP/DPXApUXt8GbKj4=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "rbush": "^2.0.1"
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x"
       },
       "dependencies": {
-        "quickselect": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
-          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+        "@turf/helpers": {
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
+          "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
         },
-        "rbush": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
-          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+        "@turf/meta": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
+          "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
           "requires": {
-            "quickselect": "^1.0.1"
+            "@turf/helpers": "6.x"
           }
         }
-      }
-    },
-    "@turf/combine": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
-      "integrity": "sha1-uxS976VVBDVxlfwaEkzX1TqMiQU=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/concave": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
-      "integrity": "sha1-I7uqw4fQNLlldKG9cNBZI3qdIRA=",
-      "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/tin": "^5.1.5",
-        "topojson-client": "3.x",
-        "topojson-server": "3.x"
-      }
-    },
-    "@turf/convex": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
-      "integrity": "sha1-Dfk3fdACIWzpghsH9wXgN9rj4B0=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "concaveman": "*"
-      }
-    },
-    "@turf/destination": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
-      "integrity": "sha1-7TU4G9zoO73cvQei4rzivd/7zCY=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/difference": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
-      "integrity": "sha1-ok1pCnvKgD8QkKnuO52Qb8Q3H0I=",
-      "requires": {
-        "@turf/area": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "turf-jsts": "*"
-      }
-    },
-    "@turf/dissolve": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
-      "integrity": "sha1-LPEzqQIdIWODHD16lY1lB/nYGTg=",
-      "requires": {
-        "@turf/boolean-overlap": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/union": "^5.1.5",
-        "geojson-rbush": "2.1.0",
-        "get-closest": "*"
-      }
-    },
-    "@turf/distance": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
-      "integrity": "sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/ellipse": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
-      "integrity": "sha1-1XyrhTmFkgzeYCKKeNgEWAJcVL4=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/transform-rotate": "^5.1.5"
-      }
-    },
-    "@turf/envelope": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
-      "integrity": "sha1-UBMwnFP91D369LWIplw/7X28EIo=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/bbox-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/explode": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
-      "integrity": "sha1-sSsvd0AEobSPYrqVsgocZVo94Rg=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/flatten": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
-      "integrity": "sha1-2iknBnEz7WFpsLnWB7khVoiqE1g=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/flip": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
-      "integrity": "sha1-Q29kOnIvDKU7n85jjkaT2zYIpoo=",
-      "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/great-circle": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
-      "integrity": "sha1-3r+2cc5HVQnLY3MBwV/PzPo1mpM=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
       }
     },
     "@turf/helpers": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-      "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
-    },
-    "@turf/hex-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
-      "integrity": "sha1-m3ul/s9QUfHoWJL3E/zlxVBQKmo=",
-      "requires": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/intersect": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/interpolate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
-      "integrity": "sha1-DxLwq3VtbdEK+ykMpuh3ve8BPqo=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/hex-grid": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/point-grid": "^5.1.5",
-        "@turf/square-grid": "^5.1.5",
-        "@turf/triangle-grid": "^5.1.5"
-      }
-    },
-    "@turf/intersect": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
-      "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
-      "requires": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/truncate": "^5.1.5",
-        "turf-jsts": "*"
-      }
-    },
-    "@turf/invariant": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
-      "integrity": "sha1-9Z9P76CSJLFdzhZR+QPIaNV6JOE=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/isobands": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
-      "integrity": "sha1-a0TO9YTVUaMTBBh68jtKFYLj8I0=",
-      "requires": {
-        "@turf/area": "^5.1.5",
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/explode": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/isolines": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
-      "integrity": "sha1-irTn9Cuz38VGFOW/FVln9+VdLeE=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/kinks": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
-      "integrity": "sha1-irtpYdm7AQchO63fLCwmQNAlaYA=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/length": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
-      "integrity": "sha1-86X4ZMK5lqi7RxeUU1ofrxLuvvs=",
-      "requires": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/line-arc": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
-      "integrity": "sha1-AHinRHg1oSrkFKIR+aZNEYYVDhU=",
-      "requires": {
-        "@turf/circle": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/line-chunk": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
-      "integrity": "sha1-kQqFwFwG2dD5w4l3oF4IGNUIXEI=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/length": "^5.1.5",
-        "@turf/line-slice-along": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/line-intersect": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
-      "integrity": "sha1-DikHGuQDKV5JFyO8SfXPrI0R3fM=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "geojson-rbush": "2.1.0"
-      }
-    },
-    "@turf/line-offset": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
-      "integrity": "sha1-KrWy8In4yRPiMdmUN4553KkLWh4=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/line-overlap": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
-      "integrity": "sha1-lDxvh6A4bcQ9+sEdKz/5wRLNP2A=",
-      "requires": {
-        "@turf/boolean-point-on-line": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/nearest-point-on-line": "^5.1.5",
-        "geojson-rbush": "2.1.0"
-      }
-    },
-    "@turf/line-segment": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
-      "integrity": "sha1-Mgeq7lRqskw9jcPMY/kcdwuAE+U=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/line-slice": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
-      "integrity": "sha1-Hs/OFGKjeFeXVM7fRGTN4mgp8rU=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/nearest-point-on-line": "^5.1.5"
-      }
-    },
-    "@turf/line-slice-along": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
-      "integrity": "sha1-7drQoh70efKWihG9LdcomiEy6aU=",
-      "requires": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/line-split": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
-      "integrity": "sha1-Wy30w3YZty73JbUWPPmSbVVArLc=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/nearest-point-on-line": "^5.1.5",
-        "@turf/square": "^5.1.5",
-        "@turf/truncate": "^5.1.5",
-        "geojson-rbush": "2.1.0"
-      }
-    },
-    "@turf/line-to-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
-      "integrity": "sha1-ITz0Gmj4Ikd4ujnTGH3sPouBhlo=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/mask": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
-      "integrity": "sha1-mrD+8aJyyY/j70kvn/thggayQtU=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/union": "^5.1.5",
-        "rbush": "^2.0.1"
-      },
-      "dependencies": {
-        "quickselect": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
-          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
-        },
-        "rbush": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
-          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
-          "requires": {
-            "quickselect": "^1.0.1"
-          }
-        }
-      }
-    },
-    "@turf/meta": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
-      "integrity": "sha1-wgqGPt7Qhp+yhUje6Ik0G8y0akY=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/midpoint": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
-      "integrity": "sha1-4mH2srDqgSTM7/VSomLdRlydBfA=",
-      "requires": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/nearest-point": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
-      "integrity": "sha1-EgUN5Bw5hEMiTHl43g9iE5ANNPs=",
-      "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/nearest-point-on-line": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
-      "integrity": "sha1-VgauKX8VlHUkvqUaKp71HsG/nDY=",
-      "requires": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/nearest-point-to-line": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
-      "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
-      "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x",
-        "@turf/point-to-line-distance": "^5.1.5",
-        "object-assign": "*"
-      },
-      "dependencies": {
-        "@turf/helpers": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-          "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
-        },
-        "@turf/invariant": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
-          "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
-          "requires": {
-            "@turf/helpers": "6.x"
-          }
-        },
-        "@turf/meta": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
-          "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
-          "requires": {
-            "@turf/helpers": "6.x"
-          }
-        }
-      }
-    },
-    "@turf/planepoint": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
-      "integrity": "sha1-GLvfAG91ne9eQsagBsn53oGyt/8=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/point-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
-      "integrity": "sha1-MFFBJI9Quv42zn5mukuX56sjaIc=",
-      "requires": {
-        "@turf/boolean-within": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/point-on-feature": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
-      "integrity": "sha1-MMfwMkMCd8ZBjZbSieRba/shP+c=",
-      "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/explode": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/nearest-point": "^5.1.5"
-      }
-    },
-    "@turf/point-to-line-distance": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
-      "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
-      "requires": {
-        "@turf/bearing": "6.x",
-        "@turf/distance": "6.x",
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x",
-        "@turf/projection": "6.x",
-        "@turf/rhumb-bearing": "6.x",
-        "@turf/rhumb-distance": "6.x"
-      },
-      "dependencies": {
-        "@turf/bearing": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.0.1.tgz",
-          "integrity": "sha512-mXY1NozqV9EFfBTbUItujwfqfQF0G/Xe2fzvnZle90ekPEUfhi4Dgf5JswJTd96J9LiT8kcd6Jonp5khnx0wIg==",
-          "requires": {
-            "@turf/helpers": "6.x",
-            "@turf/invariant": "6.x"
-          }
-        },
-        "@turf/clone": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.0.2.tgz",
-          "integrity": "sha512-UVpYPnW3wRj3bPncR6Z2PRbowBk+nEdVWgGewPxrKKLfvswtVtG9n/OIyvbU3E3ZOadBVxTH2uAMEMOz4800FA==",
-          "requires": {
-            "@turf/helpers": "6.x"
-          }
-        },
-        "@turf/distance": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.0.1.tgz",
-          "integrity": "sha512-q7t7rWIWfkg7MP1Vt4uLjSEhe5rPfCO2JjpKmk7JC+QZKEQkuvHEqy3ejW1iC7Kw5ZcZNR3qdMGGz+6HnVwqvg==",
-          "requires": {
-            "@turf/helpers": "6.x",
-            "@turf/invariant": "6.x"
-          }
-        },
-        "@turf/helpers": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-          "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
-        },
-        "@turf/invariant": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
-          "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
-          "requires": {
-            "@turf/helpers": "6.x"
-          }
-        },
-        "@turf/meta": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
-          "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
-          "requires": {
-            "@turf/helpers": "6.x"
-          }
-        },
-        "@turf/projection": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.0.1.tgz",
-          "integrity": "sha512-Y3RvGT6I53MjYKLG69e9sMk45wJXcLbrEO1t6P3WQQQGqA2gYhhMJyV41vE2Z2llrJpvs2dDx/tIeQzGd0HHMQ==",
-          "requires": {
-            "@turf/clone": "6.x",
-            "@turf/helpers": "6.x",
-            "@turf/meta": "6.x"
-          }
-        },
-        "@turf/rhumb-bearing": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.0.1.tgz",
-          "integrity": "sha512-MVBra8OVfjM4+/N0B3o6cBIYg9p/uRKzA9uk05RfrzasEbUL1vdD23LkTooVL74Yw4UxL8BQD9hS5Re2COJFDA==",
-          "requires": {
-            "@turf/helpers": "6.x",
-            "@turf/invariant": "6.x"
-          }
-        },
-        "@turf/rhumb-distance": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.0.1.tgz",
-          "integrity": "sha512-3G45DQtQByzzfHFPcCyJdUZFwsd45zfZ7sAb1ddF7mhEj4G70+T2G3GKjInymqDNrbyh2gbG6wQiZSToC8Uf9g==",
-          "requires": {
-            "@turf/helpers": "6.x",
-            "@turf/invariant": "6.x"
-          }
-        }
-      }
-    },
-    "@turf/points-within-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
-      "integrity": "sha1-K4VaXfOq2lfC7oIKB1SrlJKKIzc=",
-      "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/polygon-tangents": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
-      "integrity": "sha1-K/AJkUcwJbF44lDcfLmuVAm71lI=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/polygon-to-line": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
-      "integrity": "sha1-I7tEjYTcTGUZmaxhGjbZHFklA2o=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/polygonize": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
-      "integrity": "sha1-BJP6EYefOdELmtAs5qI+lC0IqjI=",
-      "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/envelope": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/projection": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
-      "integrity": "sha1-JFF+7rLzaBa6n3EueubWo2jt91c=",
-      "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/random": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
-      "integrity": "sha1-sy78k0Vgroulfo67UfJBw5+6Lns=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/rewind": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
-      "integrity": "sha1-nqPbSmi3PB/R3RH1djGxQ8/vock=",
-      "requires": {
-        "@turf/boolean-clockwise": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/rhumb-bearing": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-      "integrity": "sha1-rPalAkJ+uMSeGM2mrg7/qwxd3NI=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/rhumb-destination": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
-      "integrity": "sha1-sbKuuSFUfyrAwamUtqEw+SRjx0I=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/rhumb-distance": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-      "integrity": "sha1-GAaFdiX0IlOE2tQT5p85U4/192U=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/sample": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
-      "integrity": "sha1-6ctEikeJzFbuPeLdZ4HiNDQ1tBE=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/sector": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
-      "integrity": "sha1-rCu5TBPt1gNPb9wrZwCBNdIPXgc=",
-      "requires": {
-        "@turf/circle": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-arc": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/shortest-path": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
-      "integrity": "sha1-hUroCW9rw+EwD6ynfz6PZ9j5Nas=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/bbox-polygon": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/transform-scale": "^5.1.5"
-      }
-    },
-    "@turf/simplify": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
-      "integrity": "sha1-Csjyei60IYGD7dmZjDJ1q+QIuSY=",
-      "requires": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/square": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
-      "integrity": "sha1-qnsh5gM8ySUsOlvW89iNq9b+0YA=",
-      "requires": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/square-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
-      "integrity": "sha1-G9X3uesU8LYLwjH+/nNR0aMvGlE=",
-      "requires": {
-        "@turf/boolean-contains": "^5.1.5",
-        "@turf/boolean-overlap": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/intersect": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/standard-deviational-ellipse": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
-      "integrity": "sha1-hc0oO14ayljyG9ZkEuQUtW2FIyQ=",
-      "requires": {
-        "@turf/center-mean": "^5.1.5",
-        "@turf/ellipse": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/points-within-polygon": "^5.1.5"
-      }
-    },
-    "@turf/tag": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
-      "integrity": "sha1-0e4aUIjs/UoUEQGcmCOczypJfSA=",
-      "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/tesselate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
-      "integrity": "sha1-MqWU6cIaAEIKn5DSxD3z4RZgYc0=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "earcut": "^2.0.0"
-      }
-    },
-    "@turf/tin": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
-      "integrity": "sha1-KCI+r8X76a6azKgc3P6l0UJMkX0=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/transform-rotate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
-      "integrity": "sha1-0Jbt2eMA/jFQadVNjkWMQJIh7fs=",
-      "requires": {
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/rhumb-distance": "^5.1.5"
-      }
-    },
-    "@turf/transform-scale": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
-      "integrity": "sha1-cP064BhWz3uunxWtVhzf6PiQAbk=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/rhumb-distance": "^5.1.5"
-      }
-    },
-    "@turf/transform-translate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
-      "integrity": "sha1-Uwolf7Hccmja3Ks05nkB6yo97GM=",
-      "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5"
-      }
-    },
-    "@turf/triangle-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
-      "integrity": "sha1-ezZ2IQhVTBTyjK/zxIsc/ILI3IE=",
-      "requires": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/intersect": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/truncate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
-      "integrity": "sha1-nu37Oxi6gfLJjT6tCUMcyhiErYk=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/turf": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
-      "integrity": "sha1-wxIlkoh+0jS3VGi4qMRb+Ib7+PY=",
-      "requires": {
-        "@turf/along": "5.1.x",
-        "@turf/area": "5.1.x",
-        "@turf/bbox": "5.1.x",
-        "@turf/bbox-clip": "5.1.x",
-        "@turf/bbox-polygon": "5.1.x",
-        "@turf/bearing": "5.1.x",
-        "@turf/bezier-spline": "5.1.x",
-        "@turf/boolean-clockwise": "5.1.x",
-        "@turf/boolean-contains": "5.1.x",
-        "@turf/boolean-crosses": "5.1.x",
-        "@turf/boolean-disjoint": "5.1.x",
-        "@turf/boolean-equal": "5.1.x",
-        "@turf/boolean-overlap": "5.1.x",
-        "@turf/boolean-parallel": "5.1.x",
-        "@turf/boolean-point-in-polygon": "5.1.x",
-        "@turf/boolean-point-on-line": "5.1.x",
-        "@turf/boolean-within": "5.1.x",
-        "@turf/buffer": "5.1.x",
-        "@turf/center": "5.1.x",
-        "@turf/center-mean": "5.1.x",
-        "@turf/center-median": "5.1.x",
-        "@turf/center-of-mass": "5.1.x",
-        "@turf/centroid": "5.1.x",
-        "@turf/circle": "5.1.x",
-        "@turf/clean-coords": "5.1.x",
-        "@turf/clone": "5.1.x",
-        "@turf/clusters": "5.1.x",
-        "@turf/clusters-dbscan": "5.1.x",
-        "@turf/clusters-kmeans": "5.1.x",
-        "@turf/collect": "5.1.x",
-        "@turf/combine": "5.1.x",
-        "@turf/concave": "5.1.x",
-        "@turf/convex": "5.1.x",
-        "@turf/destination": "5.1.x",
-        "@turf/difference": "5.1.x",
-        "@turf/dissolve": "5.1.x",
-        "@turf/distance": "5.1.x",
-        "@turf/ellipse": "5.1.x",
-        "@turf/envelope": "5.1.x",
-        "@turf/explode": "5.1.x",
-        "@turf/flatten": "5.1.x",
-        "@turf/flip": "5.1.x",
-        "@turf/great-circle": "5.1.x",
-        "@turf/helpers": "5.1.x",
-        "@turf/hex-grid": "5.1.x",
-        "@turf/interpolate": "5.1.x",
-        "@turf/intersect": "5.1.x",
-        "@turf/invariant": "5.1.x",
-        "@turf/isobands": "5.1.x",
-        "@turf/isolines": "5.1.x",
-        "@turf/kinks": "5.1.x",
-        "@turf/length": "5.1.x",
-        "@turf/line-arc": "5.1.x",
-        "@turf/line-chunk": "5.1.x",
-        "@turf/line-intersect": "5.1.x",
-        "@turf/line-offset": "5.1.x",
-        "@turf/line-overlap": "5.1.x",
-        "@turf/line-segment": "5.1.x",
-        "@turf/line-slice": "5.1.x",
-        "@turf/line-slice-along": "5.1.x",
-        "@turf/line-split": "5.1.x",
-        "@turf/line-to-polygon": "5.1.x",
-        "@turf/mask": "5.1.x",
-        "@turf/meta": "5.1.x",
-        "@turf/midpoint": "5.1.x",
-        "@turf/nearest-point": "5.1.x",
-        "@turf/nearest-point-on-line": "5.1.x",
-        "@turf/nearest-point-to-line": "5.1.x",
-        "@turf/planepoint": "5.1.x",
-        "@turf/point-grid": "5.1.x",
-        "@turf/point-on-feature": "5.1.x",
-        "@turf/point-to-line-distance": "5.1.x",
-        "@turf/points-within-polygon": "5.1.x",
-        "@turf/polygon-tangents": "5.1.x",
-        "@turf/polygon-to-line": "5.1.x",
-        "@turf/polygonize": "5.1.x",
-        "@turf/projection": "5.1.x",
-        "@turf/random": "5.1.x",
-        "@turf/rewind": "5.1.x",
-        "@turf/rhumb-bearing": "5.1.x",
-        "@turf/rhumb-destination": "5.1.x",
-        "@turf/rhumb-distance": "5.1.x",
-        "@turf/sample": "5.1.x",
-        "@turf/sector": "5.1.x",
-        "@turf/shortest-path": "5.1.x",
-        "@turf/simplify": "5.1.x",
-        "@turf/square": "5.1.x",
-        "@turf/square-grid": "5.1.x",
-        "@turf/standard-deviational-ellipse": "5.1.x",
-        "@turf/tag": "5.1.x",
-        "@turf/tesselate": "5.1.x",
-        "@turf/tin": "5.1.x",
-        "@turf/transform-rotate": "5.1.x",
-        "@turf/transform-scale": "5.1.x",
-        "@turf/transform-translate": "5.1.x",
-        "@turf/triangle-grid": "5.1.x",
-        "@turf/truncate": "5.1.x",
-        "@turf/union": "5.1.x",
-        "@turf/unkink-polygon": "5.1.x",
-        "@turf/voronoi": "5.1.x"
-      }
-    },
-    "@turf/union": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
-      "integrity": "sha1-UyhbYJQEf8WNlqrA6pCGXsNNRUs=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "turf-jsts": "*"
-      }
-    },
-    "@turf/unkink-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
-      "integrity": "sha1-ewGEfFD7V0riV54Z5Ey6hSbSE8M=",
-      "requires": {
-        "@turf/area": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "rbush": "^2.0.1"
-      },
-      "dependencies": {
-        "quickselect": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
-          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
-        },
-        "rbush": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
-          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
-          "requires": {
-            "quickselect": "^1.0.1"
-          }
-        }
-      }
-    },
-    "@turf/voronoi": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
-      "integrity": "sha1-6FbpQG3MLyXWbdyJhYTifC6/ymY=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "d3-voronoi": "1.1.2"
-      }
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
+      "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
     },
     "@types/color-name": {
       "version": "1.1.1",
@@ -3519,11 +2262,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
       "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
-    },
-    "ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
     },
     "anymatch": {
       "version": "2.0.0",
@@ -4482,15 +3220,6 @@
       "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
       "dev": true
     },
-    "cardinal": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
-      "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
-      "requires": {
-        "ansicolors": "~0.2.1",
-        "redeyed": "~0.4.0"
-      }
-    },
     "cfb": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.1.4.tgz",
@@ -4916,33 +3645,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
-      }
-    },
-    "concaveman": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.1.1.tgz",
-      "integrity": "sha1-bCSCWAslI874L8K+wAoEFebmgWI=",
-      "requires": {
-        "monotone-convex-hull-2d": "^1.0.1",
-        "point-in-polygon": "^1.0.1",
-        "rbush": "^2.0.1",
-        "robust-orientation": "^1.1.3",
-        "tinyqueue": "^1.1.0"
-      },
-      "dependencies": {
-        "quickselect": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
-          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
-        },
-        "rbush": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
-          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
-          "requires": {
-            "quickselect": "^1.0.1"
-          }
-        }
       }
     },
     "configstore": {
@@ -5465,11 +4167,6 @@
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
-    "d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
-    },
     "d3-dispatch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
@@ -5484,23 +4181,10 @@
         "d3-selection": "1"
       }
     },
-    "d3-geo": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
-      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
-      "requires": {
-        "d3-array": "1"
-      }
-    },
     "d3-selection": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.1.tgz",
       "integrity": "sha512-BTIbRjv/m5rcVTfBs4AMBLKs4x8XaaLkwm28KWu9S2vKNqXkXt2AH2Qf0sdPZHjFxcWg/YL53zcqAz+3g4/7PA=="
-    },
-    "d3-voronoi": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-      "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
     },
     "de-indent": {
       "version": "1.0.2",
@@ -5519,19 +4203,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-    },
-    "deep-equal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "requires": {
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
-      }
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -5608,11 +4279,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defu/-/defu-1.0.0.tgz",
       "integrity": "sha512-1Y1KRFxiiq+LYsZ3iP7xYSR8bHfmHFOUpDunZCN1ld1fGfDJWJIvkUBtjl3apnBwPuJtL/H7cwwlLYX8xPkraQ=="
-    },
-    "density-clustering": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/density-clustering/-/density-clustering-1.3.0.tgz",
-      "integrity": "sha1-3J9ZyPCrl+FiSsZJMP0xlIF9ysU="
     },
     "depd": {
       "version": "1.1.2",
@@ -6293,11 +4959,6 @@
         "acorn-jsx": "^5.0.0",
         "eslint-visitor-keys": "^1.0.0"
       }
-    },
-    "esprima": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
     },
     "esquery": {
       "version": "1.2.0",
@@ -7421,14 +6082,6 @@
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
       "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
     },
-    "geojson-equality": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/geojson-equality/-/geojson-equality-0.1.6.tgz",
-      "integrity": "sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=",
-      "requires": {
-        "deep-equal": "^1.0.0"
-      }
-    },
     "geojson-flatten": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/geojson-flatten/-/geojson-flatten-0.2.4.tgz",
@@ -7436,27 +6089,19 @@
       "requires": {
         "get-stdin": "^6.0.0",
         "minimist": "1.2.0"
-      }
-    },
-    "geojson-rbush": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
-      "integrity": "sha1-O9c745H8ELCuaT2bis6iquC4Oo0=",
-      "requires": {
-        "@turf/helpers": "*",
-        "@turf/meta": "*",
-        "rbush": "*"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
       }
     },
     "geojson-vt": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
       "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
-    },
-    "get-closest": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/get-closest/-/get-closest-0.0.4.tgz",
-      "integrity": "sha1-JprHdtHmAiqg/Vht1wjop9Miaa8="
     },
     "get-stdin": {
       "version": "6.0.0",
@@ -8816,11 +7461,6 @@
         "immediate": "~3.0.5"
       }
     },
-    "lineclip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
-      "integrity": "sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM="
-    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -9055,40 +7695,35 @@
       }
     },
     "mapbox-gl": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.9.1.tgz",
-      "integrity": "sha512-jpBcqh+4qpOkj8RdxRdvwKPA8gzNYyMQ8HOcXgZYuEM5nKevRDjD3cEs+rUxi1JuYj4t8bIk68Lfh7aQQC1MjQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.0.tgz",
+      "integrity": "sha512-SrJXcR9s5yEsPuW2kKKumA1KqYW9RrL8j7ZcIh6glRQ/x3lwNMfwz/UEJAJcVNgeX+fiwzuBoDIdeGB/vSkZLQ==",
       "requires": {
-        "@mapbox/geojson-rewind": "^0.4.0",
+        "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.4.0",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
         "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
         "@mapbox/unitbezier": "^0.0.0",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.2",
+        "csscolorparser": "~1.0.3",
         "earcut": "^2.2.2",
         "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.0.0",
+        "gl-matrix": "^3.2.1",
         "grid-index": "^1.1.0",
-        "minimist": "0.0.8",
+        "minimist": "^1.2.5",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.2.1",
         "potpack": "^1.0.1",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
         "supercluster": "^7.0.0",
-        "tinyqueue": "^2.0.0",
+        "tinyqueue": "^2.0.3",
         "vt-pbf": "^3.1.1"
       },
       "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        },
         "rw": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
@@ -9244,9 +7879,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "3.1.1",
@@ -9335,14 +7970,6 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
-    },
-    "monotone-convex-hull-2d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
-      "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
-      "requires": {
-        "robust-orientation": "^1.1.3"
-      }
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -10127,11 +8754,6 @@
       "requires": {
         "find-up": "^2.1.0"
       }
-    },
-    "point-in-polygon": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.0.1.tgz",
-      "integrity": "sha1-1Ztk6P7kHElFiqyCtWcYxZV7Kvc="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -11639,14 +10261,6 @@
         "unpipe": "1.0.0"
       }
     },
-    "rbush": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
-      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
-      "requires": {
-        "quickselect": "^2.0.0"
-      }
-    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -11719,14 +10333,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "redeyed": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
-      "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
-      "requires": {
-        "esprima": "~1.0.4"
-      }
-    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -11761,15 +10367,6 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
-      }
-    },
-    "regexp.prototype.flags": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
-      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
       }
     },
     "regexpp": {
@@ -12007,36 +10604,6 @@
         "inherits": "^2.0.1"
       }
     },
-    "robust-orientation": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
-      "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
-      "requires": {
-        "robust-scale": "^1.0.2",
-        "robust-subtract": "^1.0.0",
-        "robust-sum": "^1.0.0",
-        "two-product": "^1.0.2"
-      }
-    },
-    "robust-scale": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
-      "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
-      "requires": {
-        "two-product": "^1.0.2",
-        "two-sum": "^1.0.0"
-      }
-    },
-    "robust-subtract": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/robust-subtract/-/robust-subtract-1.0.0.tgz",
-      "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo="
-    },
-    "robust-sum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
-      "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
-    },
     "run-async": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
@@ -12230,23 +10797,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "sharkdown": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sharkdown/-/sharkdown-0.1.1.tgz",
-      "integrity": "sha512-exwooSpmo5s45lrexgz6Q0rFQM574wYIX3iDZ7RLLqOb7IAoQZu9nxlZODU972g19sR69OIpKP2cpHTzU+PHIg==",
-      "requires": {
-        "cardinal": "~0.4.2",
-        "minimist": "0.0.5",
-        "split": "~0.2.10"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
-          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY="
-        }
-      }
-    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -12284,11 +10834,6 @@
           "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
-    },
-    "skmeans": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
-      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg=="
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -12514,14 +11059,6 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
-    },
-    "split": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
-      "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
-      "requires": {
-        "through": "2"
-      }
     },
     "split-string": {
       "version": "3.1.0",
@@ -13020,7 +11557,8 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "through2": {
       "version": "2.0.5",
@@ -13054,11 +11592,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
-    },
-    "tinyqueue": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
-      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
     },
     "tmp": {
       "version": "0.0.33",
@@ -13127,22 +11660,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
-    "topojson-client": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
-      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
-      "requires": {
-        "commander": "2"
-      }
-    },
-    "topojson-server": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
-      "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
-      "requires": {
-        "commander": "2"
-      }
-    },
     "toposort": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
@@ -13191,21 +11708,6 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
-    },
-    "turf-jsts": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
-      "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA=="
-    },
-    "two-product": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/two-product/-/two-product-1.0.2.tgz",
-      "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo="
-    },
-    "two-sum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/two-sum/-/two-sum-1.0.0.tgz",
-      "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q="
     },
     "type-check": {
       "version": "0.3.2",
@@ -14402,6 +12904,11 @@
         }
       }
     },
+    "wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw=="
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -14563,17 +13070,18 @@
       "dev": true
     },
     "xlsx": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.14.5.tgz",
-      "integrity": "sha512-s/5f4/mjeWREmIWZ+HtDfh/rnz51ar+dZ4LWKZU3u9VBx2zLdSIWTdXgoa52/pnZ9Oe/Vu1W1qzcKzLVe+lq4w==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.16.0.tgz",
+      "integrity": "sha512-W/LQZjh6o7WDGmCIUXp2FUPSej2XRdaiTgZN31Oh68JlL7jpm796p3eI5zOpphYNT12qkgnXYaCysAsoiyZvOQ==",
       "requires": {
         "adler-32": "~1.2.0",
-        "cfb": "^1.1.2",
+        "cfb": "^1.1.4",
         "codepage": "~1.14.0",
         "commander": "~2.17.1",
         "crc-32": "~1.2.0",
         "exit-on-epipe": "~1.0.1",
-        "ssf": "~0.10.2"
+        "ssf": "~0.10.3",
+        "wmf": "~1.0.1"
       },
       "dependencies": {
         "commander": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fruchtfolge",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "sideEffects": false,
   "description": "Fruchtfolge client application",
   "author": "Christoph Pahmeyer <christoph.pahmeyer@ilr.uni-bonn.de>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "fruchtfolge",
-  "version": "2.1.1",
+  "version": "2.1.2",
+  "sideEffects": false,
   "description": "Fruchtfolge client application",
   "author": "Christoph Pahmeyer <christoph.pahmeyer@ilr.uni-bonn.de>",
   "license": "GPL-3.0-or-later",
@@ -17,7 +18,9 @@
     "@mapbox/mapbox-gl-draw": "^1.1.2",
     "@nuxtjs/axios": "^5.6.0",
     "@nuxtjs/google-analytics": "^2.2.3",
-    "@turf/turf": "^5.1.6",
+    "@turf/area": "^6.0.1",
+    "@turf/bbox": "^6.0.1",
+    "@turf/helpers": "^6.1.4",
     "axios": "^0.19.0",
     "bufferutil": "^4.0.1",
     "chart.js": "^2.8.0",
@@ -27,7 +30,7 @@
     "cross-env": "^5.2.1",
     "fold-to-ascii": "^4.1.2",
     "lodash": "^4.17.15",
-    "mapbox-gl": "^1.8.1",
+    "mapbox-gl": "^1.10.0",
     "mini-toastr": "^0.8.1",
     "nuxt": "^2.12.0",
     "pouchdb": "^7.1.1",
@@ -38,7 +41,7 @@
     "vue-clickaway": "^2.2.2",
     "vue-multiselect": "^2.1.6",
     "vue-notifications": "^1.0.2",
-    "xlsx": "^0.14.5"
+    "xlsx": "^0.16.0"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config": "^0.0.1",

--- a/pages/crop-labour-requirement.vue
+++ b/pages/crop-labour-requirement.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="page-container">
+    <div class="page-container printFixOverflow">
       <addCrop v-if="addCrop" @closeAddCrop="addCrop = false" />
       <cropsSidebar :crops="crops" :selected-crop="selectedCrop" @showAddCrop="addCrop = true" @changeCrop="changeCrop" />
       <cropLabour v-if="selectedCrop" :crop="selectedCrop" />

--- a/pages/labour.vue
+++ b/pages/labour.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="">
+  <div class="printFixOverflow">
     <div class="chart-wrapper">
       <canvas id="labour-chart" />
     </div>

--- a/pages/n-fertilizer-planning.vue
+++ b/pages/n-fertilizer-planning.vue
@@ -1,24 +1,52 @@
 <template>
   <div>
     <div v-if="dataAvail" class="plotOverview">
-      <table v-if="arablePlots" class="table-fert table">
+      <table v-if="arablePlots && arablePlots.length" class="table-fert table">
         <caption class="caption">
           Düngebedarfsermittlung Ackerbau
         </caption>
         <thead>
           <tr>
-            <th>Name</th>
-            <th>Kultur</th>
-            <th>Ertragsniveau 5 Jahr Ø Betrieb [dt/ha]</th>
-            <th>N-Bedarfswert [kg N/ha]</th>
-            <th>Zu- oder Abschlag Ertragsdifferenz [kg N/ha]</th>
-            <th>Abschlag Nmin-Probe/Richtwert [kg N/ha]</th>
-            <th>Abschlag Standort / Humus [kg N/ha]</th>
-            <th>Abschlag org. Düngung der Vorjahre [kg N/ha]</th>
-            <th>Abschlag Vorfrucht / ZF [kg N/ha]</th>
-            <th>Stickstoffdüngebedarf Vegetation [kg N/ha]</th>
-            <th>Planung Org. Düngung [kg N/ha]</th>
-            <th>Planung Min. Düngung [kg N/ha]</th>
+            <th rowspan="2">
+              Name
+            </th>
+            <th rowspan="2">
+              Kultur
+            </th>
+            <th rowspan="2">
+              Ertragsniveau 5 Jahre Ø Betrieb [dt/ha]
+            </th>
+            <th rowspan="2">
+              N-Bedarfswert [kg N/ha]
+            </th>
+            <th colspan="5">
+              Zu- oder Abschläge [kg N/ha]
+            </th>
+            <th rowspan="2">
+              N-Düngebedarf [kg N/ha]
+            </th>
+            <th rowspan="2">
+              N-Reduktion im roten Gebiet
+            </th>
+            <th rowspan="2">
+              N-Düngebedarf abzgl. Reduktion [kg N/ha]
+            </th>
+            <th colspan="2">
+              Planung [kg N/ha]
+            </th>
+          </tr>
+          <tr>
+            <th>Ertragsdifferenz</th>
+            <th>Nmin-Probe / Richtwert</th>
+            <th>Humusgehalt</th>
+            <th>Org. Düngung der Vorjahre</th>
+            <th>Vorfrucht / ZF</th>
+            <th>
+              Org. Düngung
+            </th>
+            <th>
+              Min. Düngung
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -54,6 +82,12 @@
               {{ plot.selectedOption.nSum }}
             </td>
             <td class="cell-number">
+              {{ plot.selectedOption.nReduction }}%
+            </td>
+            <td class="cell-number" style="font-weight: bold;">
+              {{ plot.selectedOption.reducedNSum }}
+            </td>
+            <td class="cell-number">
               {{ orgN(plot) }}
             </td>
             <td class="cell-number" style="padding-right: 10px;">
@@ -62,7 +96,7 @@
           </tr>
         </tbody>
       </table>
-      <table v-if="greenlandPlots" class="table-fert table">
+      <table v-if="greenlandPlots && greenlandPlots.length" class="table-fert table">
         <caption class="caption">
           Düngebedarfsermittlung Grünland und Feldfutter
         </caption>
@@ -253,8 +287,10 @@ export default {
 
 .table-fert {
   table-layout: fixed;
+  width: 100%;
   min-width: 800px;
-  max-width: 1024px;
+  max-width: 1300px;
+  margin: 20px 0px 0px 20px;
 }
 
 .table-fert th {

--- a/pages/results.vue
+++ b/pages/results.vue
@@ -1042,14 +1042,6 @@ export default {
   text-align: '.' center;
 }
 
-.result-table tr {
-  background-color: #ececec;
-}
-
-.result-table tr:nth-child(odd) {
-  background-color: #f5f5f5;
-}
-
 /*
 .result-table tr:nth-child(4n + 1),
 .result-table tr:nth-child(4n + 2) {

--- a/pages/timeseries.vue
+++ b/pages/timeseries.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="page-container">
+    <div class="page-container printFixOverflow">
       <addCrop v-if="addCrop" @closeAddCrop="addCrop = false" />
       <cropsSidebar :crops="crops" :selected-crop="selectedCrop" @showAddCrop="addCrop = true" @changeCrop="changeCrop" />
       <timeSeries v-if="selectedCrop" :crop="selectedCrop" />


### PR DESCRIPTION
This PR adds modern (ES6) builds to the bundle: If a modern browser requests the client page, the (smaller/faster) ES6 version is delivered, if not the larger transpiled version is sent over the wire.

Other than that, this PR fixes some minor bugs and improves printability of all pages (fixes #29)