### PR TITLE
- fix bug leading to css not being loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fruchtfolge",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1643,15 +1643,22 @@
       }
     },
     "@nuxtjs/axios": {
-      "version": "5.9.7",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/axios/-/axios-5.9.7.tgz",
-      "integrity": "sha512-GLL0/0HbRCbvyXtw6WjXxCzQjXrQwlip4N3ATesyytcfzYcQUAfxdKCaKBK7IRiW+V1mH1vrzbEK/iDlfxA/TQ==",
+      "version": "5.10.3",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/axios/-/axios-5.10.3.tgz",
+      "integrity": "sha512-cCPeix6S0yLftiTnD9cpZSDsCNYD5/5EB9Q9iB8WaNZsGMPcwM5XQQVFcenMIv9Dr+SvySdOUdDL9rvlfyhdkg==",
       "requires": {
         "@nuxtjs/proxy": "^1.3.3",
         "axios": "^0.19.2",
-        "axios-retry": "^3.1.2",
+        "axios-retry": "^3.1.8",
         "consola": "^2.11.3",
-        "defu": "^1.0.0"
+        "defu": "^2.0.2"
+      },
+      "dependencies": {
+        "defu": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/defu/-/defu-2.0.4.tgz",
+          "integrity": "sha512-G9pEH1UUMxShy6syWk01VQSRVs3CDWtlxtZu7A+NyqjxaCA4gSlWAKDBx6QiUEKezqS8+DUlXLI14Fp05Hmpwg=="
+        }
       }
     },
     "@nuxtjs/eslint-config": {
@@ -1661,9 +1668,9 @@
       "dev": true
     },
     "@nuxtjs/google-analytics": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/google-analytics/-/google-analytics-2.2.3.tgz",
-      "integrity": "sha512-dPwgsRNECtZqHdmnbJRFy3T4DDVakrpeN7vM1DwAIV1FXYlIBMKvdi8nt1v8TPU4IZdaoXrQodfeNMCooPo/7g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/google-analytics/-/google-analytics-2.3.0.tgz",
+      "integrity": "sha512-TBRWCZJJBywNU4Sxbe03w5uy76O9JiOJz5ZgFDAmU06IUhwMELWOoQFWTqgROmvhqzoZrXMPR5JiaEnvaCRuDA==",
       "requires": {
         "vue-analytics": "^5.22.1"
       }
@@ -2459,9 +2466,9 @@
       }
     },
     "axios-retry": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.2.tgz",
-      "integrity": "sha512-+X0mtJ3S0mmia1kTVi1eA3DAC+oWnT2A29g3CpkzcBPMT6vJm+hn/WiV9wPt/KXLHVmg5zev9mWqkPx7bHMovg==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.8.tgz",
+      "integrity": "sha512-yPw5Y4Bg6Dgmhm35KaJFtlh23s1TecW0HsUerK4/IS1UKl0gtN2aJqdEKtVomiOS/bDo5w4P3sqgki/M10eF8Q==",
       "requires": {
         "is-retry-allowed": "^1.1.0"
       }
@@ -5006,9 +5013,9 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter3": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
     },
     "events": {
       "version": "3.1.0",
@@ -6556,9 +6563,9 @@
       }
     },
     "http-proxy": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
-      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "requires": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -6566,11 +6573,11 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
-      "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.2.tgz",
+      "integrity": "sha512-aYk1rTKqLTus23X3L96LGNCGNgWpG4cG0XoZIT1GUPhhulEHX/QalnO6Vbo+WmKWi4AL2IidjuC0wZtbpg0yhQ==",
       "requires": {
-        "http-proxy": "^1.17.0",
+        "http-proxy": "^1.18.1",
         "is-glob": "^4.0.0",
         "lodash": "^4.17.11",
         "micromatch": "^3.1.10"
@@ -7695,9 +7702,9 @@
       }
     },
     "mapbox-gl": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.0.tgz",
-      "integrity": "sha512-SrJXcR9s5yEsPuW2kKKumA1KqYW9RrL8j7ZcIh6glRQ/x3lwNMfwz/UEJAJcVNgeX+fiwzuBoDIdeGB/vSkZLQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
+      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
       "requires": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
@@ -7728,11 +7735,6 @@
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
           "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
-        },
-        "tinyqueue": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-          "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
         }
       }
     },
@@ -11593,6 +11595,11 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -13070,9 +13077,9 @@
       "dev": true
     },
     "xlsx": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.16.0.tgz",
-      "integrity": "sha512-W/LQZjh6o7WDGmCIUXp2FUPSej2XRdaiTgZN31Oh68JlL7jpm796p3eI5zOpphYNT12qkgnXYaCysAsoiyZvOQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.16.1.tgz",
+      "integrity": "sha512-0feXqUm6W6/h+2bGSX2nkjVHCJ7cjq6pjcFixMTLlmNYrvm+nHg1BUIqyu+3Hlax7K5EbmUWqVxS3X0kuZQGvg==",
       "requires": {
         "adler-32": "~1.2.0",
         "cfb": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fruchtfolge",
   "version": "2.1.3",
-  "sideEffects": false,
+  "sideEffects": true,
   "description": "Fruchtfolge client application",
   "author": "Christoph Pahmeyer <christoph.pahmeyer@ilr.uni-bonn.de>",
   "license": "GPL-3.0-or-later",
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@mapbox/mapbox-gl-draw": "^1.1.2",
-    "@nuxtjs/axios": "^5.6.0",
-    "@nuxtjs/google-analytics": "^2.2.3",
+    "@nuxtjs/axios": "^5.10.3",
+    "@nuxtjs/google-analytics": "^2.3.0",
     "@turf/area": "^6.0.1",
     "@turf/bbox": "^6.0.1",
     "@turf/helpers": "^6.1.4",
@@ -30,7 +30,7 @@
     "cross-env": "^5.2.1",
     "fold-to-ascii": "^4.1.2",
     "lodash": "^4.17.15",
-    "mapbox-gl": "^1.10.0",
+    "mapbox-gl": "^1.10.1",
     "mini-toastr": "^0.8.1",
     "nuxt": "^2.12.0",
     "pouchdb": "^7.1.1",
@@ -41,7 +41,7 @@
     "vue-clickaway": "^2.2.2",
     "vue-multiselect": "^2.1.6",
     "vue-notifications": "^1.0.2",
-    "xlsx": "^0.16.0"
+    "xlsx": "^0.16.1"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config": "^0.0.1",


### PR DESCRIPTION
For some reason, adding `sideEffects: false` (used to indicate that `imports` have no side effects -> reduces bundle sizes in modern builds) removed all CSS from the production build. Seems like a Nuxt/Webpack bug

Fixed by setting `sideEffects: true` for now